### PR TITLE
Add unit test to cover `overwrite` param, refactor `fgdb_to_gpkg()` to handle overwrites correctly

### DIFF
--- a/fgdb_to_gpkg/fgdb_to_gpkg.py
+++ b/fgdb_to_gpkg/fgdb_to_gpkg.py
@@ -23,7 +23,7 @@ def fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True, **kwargs):
     try:
         # Ensure input File GeoDataBase exists
         if not os.path.exists(fgdb_path):
-            raise ValueError(f"{fgdb_path} does not exist!")
+            raise FileNotFoundError(f"{fgdb_path} does not exist!")
 
         # Remove existing GeoPackage if overwrite is True
         if os.path.exists(gpkg_path) and overwrite:
@@ -37,6 +37,13 @@ def fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True, **kwargs):
 
         # Loop through each feature class
         for fc in fc_list:
+            # Check if layer exists in GeoPackage when not overwriting
+            if not overwrite and os.path.exists(gpkg_path):
+                with fiona.open(gpkg_path, "r") as gpkg:
+                    if fc in gpkg:
+                        print(f"Layer {fc} already exists in {gpkg_path}. Skipping...")
+                        continue
+
             # Read the feature class into GeoDataFrame
             gdf = gpd.read_file(fgdb_path, layer=fc)
 

--- a/tests/test_fgdb_to_gpkg.py
+++ b/tests/test_fgdb_to_gpkg.py
@@ -1,38 +1,65 @@
-import os
+import pytest
 import tempfile
+import os
 import geopandas as gpd
 from shapely.geometry.polygon import Polygon
 from shapely.geometry.multipolygon import MultiPolygon
 from fgdb_to_gpkg import fgdb_to_gpkg
 
 
-def test_fgdb_to_gpkg():
-    # Create a temporary File GeoDatabase and GeoPackage
+@pytest.fixture
+def setup_fgdb_gpkg():
+    # Setup fixture for creating a temporary File GeoDatabase and GeoPackage
     with tempfile.TemporaryDirectory() as temp_dir:
         fgdb_path = os.path.join(temp_dir, "test.gdb")
         gpkg_path = os.path.join(temp_dir, "test.gpkg")
         layer = "test_fc"
 
-        # Create a GeoDataFrame and save it to the File GeoDatabase
+        # Create a GeoDataFrame
         gdf = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
-
-        # Promote Polygon to MultiPolygon to avoid fiona error with mixed geometries
         gdf["geometry"] = [
             MultiPolygon([feature]) if isinstance(feature, Polygon) else feature
             for feature in gdf["geometry"]
         ]
 
-        # Write gdf to File GeoDataBase
+        # Write the GeoDataFrame to File GeoDatabase
         gdf.to_file(fgdb_path, layer=layer, driver="OpenFileGDB")
 
-        # Convert the File GeoDatabase to a GeoPackage
-        fgdb_to_gpkg(fgdb_path, gpkg_path)
+        yield fgdb_path, gpkg_path, layer
 
-        # Read the File GeoDatabase
-        gdf_fgdb = gpd.read_file(fgdb_path, layer=layer)
 
-        # Read the GeoPackage
-        gdf_gpkg = gpd.read_file(gpkg_path, layer=layer)
+def test_fgdb_to_gpkg(setup_fgdb_gpkg):
+    # Test basic functionality of fgdb_to_gpkg
+    fgdb_path, gpkg_path, layer = setup_fgdb_gpkg
 
-        # Expect each gdf to be the same
-        assert gdf_fgdb.equals(gdf_gpkg)
+    fgdb_to_gpkg(fgdb_path, gpkg_path)
+
+    # Read and compare data from File GeoDatabase and GeoPackage
+    gdf_fgdb = gpd.read_file(fgdb_path, layer=layer)
+    gdf_gpkg = gpd.read_file(gpkg_path, layer=layer)
+    assert gdf_fgdb.equals(gdf_gpkg)
+
+
+def test_fgdb_to_gpkg_overwrite(setup_fgdb_gpkg):
+    # Test the overwrite functionality of fgdb_to_gpkg
+    fgdb_path, gpkg_path, layer = setup_fgdb_gpkg
+
+    # Convert the File GeoDatabase to a GeoPackage
+    fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True)
+
+    # Modify the original GeoDataFrame
+    gdf_modified = gpd.read_file(fgdb_path, layer=layer)
+    gdf_modified["new_column"] = "test"
+
+    # Write the modified GeoDataFrame to File GeoDatabase
+    gdf_modified.to_file(fgdb_path, layer=layer, driver="OpenFileGDB")
+
+    # Convert the modified File GeoDatabase to GeoPackage with overwrite=False
+    fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=False)
+    gdf_gpkg_no_overwrite = gpd.read_file(gpkg_path, layer=layer)
+    assert "new_column" not in gdf_gpkg_no_overwrite.columns
+
+    # Convert the modified File GeoDatabase to GeoPackage with overwrite=True
+    fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True)
+    gdf_gpkg_overwrite = gpd.read_file(gpkg_path, layer=layer)
+    assert "new_column" in gdf_gpkg_overwrite.columns


### PR DESCRIPTION
This PR fixes a bug when using `fgdb_to_gpkg(overwrite=False)`. 

Previously, feature classes would still append an existing gpkg despite overwrite being set to false. Now, the function will loop through all layers within the gpkg to check if they exist before trying to write them. 

Additional unit tests have been added to cover this parameter.