### PR TITLE
Set continue-on-error to true when linting with black

### DIFF
--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -18,5 +18,6 @@ jobs:
     - name: Install Dependencies
       run: |
         pip install black 
-    - name: Check Python style
-      run: black --check .  
+    - name: Lint with Black
+      run: black --check . 
+      continue-on-error: true 


### PR DESCRIPTION
This is a quick fix to #11 to ensure that the action doesn't fail on the first linting issue.