### PR TITLE
Rename test to poetry-run-pytest

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  poetry-run-pytest:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # This ensures all matrix jobs run even if some fail


### PR DESCRIPTION
Rename the job associated with the GitHub Action that runs the unit tests from `test` to `poetry-run-pytest`.