### PR TITLE
Add nonexistent fgdb test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Unit tests can be performed by the developers of this package using the followin
 poetry run pytest tests
 ```
 
+Test coverage can be assessed using the following command:
+
+```
+poetry run pytest --cov=fgdb_to_gpkg --cov-report term-missing
+```
+
 #### Handling the Fiona GDAL compilation error
 
 The unit tests within this package depend on `gdal=^3.6.0`, but the current version of `fiona` ships with `gdal=3.5.3`. The fiona package must be installed using the `--no-binary` flag to test this package. If this is not configured properly, then you will see the following error:

--- a/fgdb_to_gpkg/fgdb_to_gpkg.py
+++ b/fgdb_to_gpkg/fgdb_to_gpkg.py
@@ -20,11 +20,11 @@ def fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True, **kwargs):
     :param **kwargs: additional keyword arguments to pass to geopandas.to_file()
     """
 
-    try:
-        # Ensure input File GeoDataBase exists
-        if not os.path.exists(fgdb_path):
-            raise FileNotFoundError(f"{fgdb_path} does not exist!")
+    # Ensure input File GeoDataBase exists
+    if not os.path.exists(fgdb_path):
+        raise FileNotFoundError(f"{fgdb_path} does not exist!")
 
+    try:
         # Remove existing GeoPackage if overwrite is True
         if os.path.exists(gpkg_path) and overwrite:
             os.remove(gpkg_path)

--- a/tests/test_fgdb_to_gpkg.py
+++ b/tests/test_fgdb_to_gpkg.py
@@ -2,6 +2,7 @@ import pytest
 import tempfile
 import os
 import geopandas as gpd
+from typing import Literal
 from shapely.geometry.polygon import Polygon
 from shapely.geometry.multipolygon import MultiPolygon
 from fgdb_to_gpkg import fgdb_to_gpkg
@@ -28,7 +29,7 @@ def setup_fgdb_gpkg():
         yield fgdb_path, gpkg_path, layer
 
 
-def test_fgdb_to_gpkg(setup_fgdb_gpkg):
+def test_fgdb_to_gpkg(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"]]):
     # Test basic functionality of fgdb_to_gpkg
     fgdb_path, gpkg_path, layer = setup_fgdb_gpkg
 
@@ -40,7 +41,7 @@ def test_fgdb_to_gpkg(setup_fgdb_gpkg):
     assert gdf_fgdb.equals(gdf_gpkg)
 
 
-def test_fgdb_to_gpkg_overwrite(setup_fgdb_gpkg):
+def test_fgdb_to_gpkg_overwrite(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"]]):
     # Test the overwrite functionality of fgdb_to_gpkg
     fgdb_path, gpkg_path, layer = setup_fgdb_gpkg
 
@@ -63,3 +64,13 @@ def test_fgdb_to_gpkg_overwrite(setup_fgdb_gpkg):
     fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True)
     gdf_gpkg_overwrite = gpd.read_file(gpkg_path, layer=layer)
     assert "new_column" in gdf_gpkg_overwrite.columns
+
+
+def test_nonexistent_fgdb(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"]]):
+    # Test that a file not found error is raised when a nonexistent fgdb is used
+    _, gpkg_path, _ = setup_fgdb_gpkg
+    nonexistent_fgdb_path = "nonexistent.fgdb"
+    with pytest.raises(FileNotFoundError) as exc_info:
+        fgdb_to_gpkg(nonexistent_fgdb_path, gpkg_path, overwrite=False)
+    # expected_error_message = f"Error converting {nonexistent_fgdb_path} to {gpkg_path}: {nonexistent_fgdb_path} does not exist!"
+    # assert str(exc_info.value) == expected_error_message

--- a/tests/test_fgdb_to_gpkg.py
+++ b/tests/test_fgdb_to_gpkg.py
@@ -70,7 +70,5 @@ def test_nonexistent_fgdb(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"]]):
     # Test that a file not found error is raised when a nonexistent fgdb is used
     _, gpkg_path, _ = setup_fgdb_gpkg
     nonexistent_fgdb_path = "nonexistent.fgdb"
-    with pytest.raises(FileNotFoundError) as exc_info:
+    with pytest.raises(FileNotFoundError):
         fgdb_to_gpkg(nonexistent_fgdb_path, gpkg_path, overwrite=False)
-    # expected_error_message = f"Error converting {nonexistent_fgdb_path} to {gpkg_path}: {nonexistent_fgdb_path} does not exist!"
-    # assert str(exc_info.value) == expected_error_message


### PR DESCRIPTION
Add test to cover when input fgdb_path parameter does not correspond to an existing .fgdb.