### PR TITLE
Add existing layer test

### DIFF
--- a/fgdb_to_gpkg/fgdb_to_gpkg.py
+++ b/fgdb_to_gpkg/fgdb_to_gpkg.py
@@ -36,18 +36,21 @@ def fgdb_to_gpkg(fgdb_path: str, gpkg_path: str, overwrite: bool = True, **kwarg
         # Create progress bar
         progress_bar = tqdm(total=len(fc_list), desc="Converting layers")
 
+        # List all layers within GeoPackage if it exists
+        gpkg_exists = os.path.exists(gpkg_path)
+        if gpkg_exists:
+            layer_list = fiona.listlayers(gpkg_path)
+
         # Loop through each feature class
         for fc in fc_list:
-            # Check if layer exists in GeoPackage when not overwriting
-            if not overwrite and os.path.exists(gpkg_path):
-                layer_list = fiona.listlayers(gpkg_path)
-                with fiona.open(gpkg_path, "r") as gpkg:
-                    if fc in layer_list:
-                        warnings.warn(
-                            f"Layer {fc} already exists in {gpkg_path}. Skipping...",
-                            UserWarning,
-                        )
-                        continue
+            # Skip writing layer if it already exists in GeoPackage when not overwriting
+            if not overwrite and gpkg_exists:
+                if fc in layer_list:
+                    warnings.warn(
+                        f"Layer {fc} already exists in {gpkg_path}. Skipping...",
+                        UserWarning,
+                    )
+                    continue
 
             # Read the feature class into GeoDataFrame
             gdf = gpd.read_file(fgdb_path, layer=fc)

--- a/fgdb_to_gpkg/fgdb_to_gpkg.py
+++ b/fgdb_to_gpkg/fgdb_to_gpkg.py
@@ -2,10 +2,11 @@ import argparse
 import geopandas as gpd
 import fiona
 import os
+import warnings
 from tqdm import tqdm
 
 
-def fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True, **kwargs):
+def fgdb_to_gpkg(fgdb_path: str, gpkg_path: str, overwrite: bool = True, **kwargs):
     """Converts all feature classes within a File GeoDataBase to new layers within a GeoPackage.
 
     :param fgdb_path: file path of an Esri File GeoDataBase (.gdb)
@@ -39,9 +40,13 @@ def fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True, **kwargs):
         for fc in fc_list:
             # Check if layer exists in GeoPackage when not overwriting
             if not overwrite and os.path.exists(gpkg_path):
+                layer_list = fiona.listlayers(gpkg_path)
                 with fiona.open(gpkg_path, "r") as gpkg:
-                    if fc in gpkg:
-                        print(f"Layer {fc} already exists in {gpkg_path}. Skipping...")
+                    if fc in layer_list:
+                        warnings.warn(
+                            f"Layer {fc} already exists in {gpkg_path}. Skipping...",
+                            UserWarning,
+                        )
                         continue
 
             # Read the feature class into GeoDataFrame

--- a/fgdb_to_gpkg/fgdb_to_gpkg.py
+++ b/fgdb_to_gpkg/fgdb_to_gpkg.py
@@ -6,7 +6,9 @@ import warnings
 from tqdm import tqdm
 
 
-def fgdb_to_gpkg(fgdb_path: str, gpkg_path: str, overwrite: bool = True, **kwargs):
+def fgdb_to_gpkg(
+    fgdb_path: str, gpkg_path: str, overwrite: bool = True, **kwargs
+) -> None:
     """Converts all feature classes within a File GeoDataBase to new layers within a GeoPackage.
 
     :param fgdb_path: file path of an Esri File GeoDataBase (.gdb)

--- a/tests/test_fgdb_to_gpkg.py
+++ b/tests/test_fgdb_to_gpkg.py
@@ -79,7 +79,7 @@ def test_nonexistent_fgdb(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"]]):
 
 
 def test_layer_already_exists(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"]]):
-    # Test the behavior when the layer already exists and overwrite is False
+    # Test the behavior when a layer already exists and overwrite is False
     fgdb_path, gpkg_path, _ = setup_fgdb_gpkg
 
     warnings.simplefilter("always")

--- a/tests/test_fgdb_to_gpkg.py
+++ b/tests/test_fgdb_to_gpkg.py
@@ -10,7 +10,7 @@ from fgdb_to_gpkg import fgdb_to_gpkg
 
 
 @pytest.fixture
-def setup_fgdb_gpkg():
+def setup_fgdb_gpkg() -> tuple[str, str, list[str]]:
     # Setup fixture for creating a temporary File GeoDatabase and GeoPackage
     with tempfile.TemporaryDirectory() as temp_dir:
         fgdb_path = os.path.join(temp_dir, "test.gdb")

--- a/tests/test_fgdb_to_gpkg.py
+++ b/tests/test_fgdb_to_gpkg.py
@@ -80,7 +80,7 @@ def test_nonexistent_fgdb(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"]]):
 
 def test_layer_already_exists(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"]]):
     # Test the behavior when the layer already exists and overwrite is False
-    fgdb_path, gpkg_path, layer = setup_fgdb_gpkg
+    fgdb_path, gpkg_path, _ = setup_fgdb_gpkg
 
     warnings.simplefilter("always")
 
@@ -88,6 +88,6 @@ def test_layer_already_exists(setup_fgdb_gpkg: tuple[str, str, Literal["test_fc"
     fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=True)
 
     # Try converting again with overwrite=False
-    # This should raise a warning because the layer already exists
+    # This should raise a warning because the layers already exists
     with pytest.warns(UserWarning) as record:
         fgdb_to_gpkg(fgdb_path, gpkg_path, overwrite=False)


### PR DESCRIPTION
Add test to check behavior when layer already exists in gpkg and overwrite is set to false.

Adds type hinting to input params. 

Fixes bug with checking for `fc in gpkg`. Need to compare against list of layers instead. 

Could be improved by avoiding duplicate `fiona.listlayers(gpkg)` calls (one for each fc in fc_list. 