### PR TITLE
Add executable cli/script/bin fgdb-to-gpkg (fixes #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ This package does not have a dependency on ArcPy, which means that you can safel
 #### Installing from PyPI
 
 ```
+# Recommended: Install globally using pipx
+pipx install fgdb-to-gpkg
+
+# Or install to a manually-created virtual environment
+python -m venv env
+./env/bin/pip install fgdb-to-gpkg
+
+# Or install to the global Python environment
 pip install fgdb-to-gpkg
 ```
 
@@ -17,15 +25,16 @@ pip install fgdb-to-gpkg
 1. Clone the repository: `git clone https://github.com/philiporlando/fgdb_to_gdb.git`
 2. Navigate to the repository directory: `cd fgdb_to_gdb`
 3. Install the package and its dependencies with [poetry](https://python-poetry.org/): `poetry install`
+4. Optionally, install the package to be run globally with pipx: `pipx install --editable .`
 
 ## Usage
 
 ### Command Line Usage
 
-To use `fgdb_to_gpkg` from the command line, simply call the `fgdb_to_gpkg` command with the path to the input File GeoDatabase and the path to the output GeoPackage:
+To use from the command line, simply call the `fgdb-to-gpkg` command with the path to the input File GeoDatabase and the path to the output GeoPackage:
 
 ```
-poetry run python -m fgdb_to_gpkg <input_fgdb_path> <output_gpkg_path>
+fgdb-to-gpkg <input_fgdb_path> <output_gpkg_path>
 ```
 
 ### Module Usage

--- a/fgdb_to_gpkg/__init__.py
+++ b/fgdb_to_gpkg/__init__.py
@@ -3,6 +3,7 @@ from .fgdb_to_gpkg import (
     fgdb_to_gpkg,
     get_layer_lists,
     remove_gpkg_if_overwrite,
+    main,
 )
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "get_layer_lists",
     "convert_layer",
     "fgdb_to_gpkg",
+    "main",
 ]

--- a/fgdb_to_gpkg/fgdb_to_gpkg.py
+++ b/fgdb_to_gpkg/fgdb_to_gpkg.py
@@ -121,7 +121,7 @@ def fgdb_to_gpkg(
         raise
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         description="Convert an Esri File GeoDatabase to a GeoPackage"
     )
@@ -135,3 +135,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     fgdb_to_gpkg(args.fgdb_path, args.gpkg_path, args.overwrite)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ geodatasets = "^2024.7.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+fgdb-to-gpkg = "fgdb_to_gpkg:main"


### PR DESCRIPTION
Adds a script `fgdb-to-gpkg`. Tested by trying to install via pipx from main and then from this branch:

```
~/C/fgdb_to_gpkg (main|✔) $ pipx install --editable .                                                                    15:13:45
Note: Dependent package 'fiona' contains 1 apps
  - fio
Note: Dependent package 'gdal' contains 18 apps
  - gdal2tiles.py
  - gdal2xyz.py
  - gdal_calc.py
  - gdal_edit.py
  - gdal_fillnodata.py
  - gdal_merge.py
  - gdal_pansharpen.py
  - gdal_polygonize.py
  - gdal_proximity.py
  - gdal_retile.py
  - gdal_sieve.py
  - gdalattachpct.py
  - gdalcompare.py
  - gdalmove.py
  - ogr_layer_algebra.py
  - ogrmerge.py
  - pct2rgb.py
  - rgb2pct.py
Note: Dependent package 'charset-normalizer' contains 1 apps
  - normalizer
Note: Dependent package 'numpy' contains 1 apps
  - f2py
Note: Dependent package 'pyproj' contains 1 apps
  - pyproj
Note: Dependent package 'tqdm' contains 1 apps
  - tqdm

No apps associated with package fgdb-to-gpkg. Try again with '--include-deps' to include apps of dependent packages, which are
listed above. If you are attempting to install a library, pipx should not be used. Consider using pip or a similar tool
instead.
~/C/fgdb_to_gpkg (main|✔) [1] $ gco add-cli                                                                              15:14:13
Switched to branch 'add-cli'
~/C/fgdb_to_gpkg (add-cli|✔) $ pipx install --editable .                                                                 15:15:28
  installed package fgdb-to-gpkg 0.2.2, installed using Python 3.12.3
  These apps are now globally available
    - fgdb-to-gpkg
done! ✨ 🌟 ✨
~/C/fgdb_to_gpkg (add-cli|✔) $ fgdb-to-gpkg --help                                                                       15:16:04
usage: fgdb-to-gpkg [-h] [--overwrite] fgdb_path gpkg_path

Convert an Esri File GeoDatabase to a GeoPackage

positional arguments:
  fgdb_path    path to the File GeoDatabase
  gpkg_path    path to the GeoPackage to create

options:
  -h, --help   show this help message and exit
  --overwrite  deletes an existing GeoPackage before copying layers from File GeoDataBase.
```